### PR TITLE
fix deployment of private link scope with cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ If `make check` target is successful, developer is good to commit the code to pr
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.110.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.107.0 |
 
 ## Modules
 


### PR DESCRIPTION
without the `depends_on` keys, the private endpoint will sometimes fail to create because the dns zone is not finished creating

also adds a comment documenting a bug with two of the examples