### PR TITLE
update naming for private link scoped services

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -38,15 +38,32 @@ locals {
     next_hop_in_ip_address = try(var.user_defined_routing.azure_firewall_private_ip_address, null)
   } : {}
 
-  monitor_private_link_scoped_resource_ids = merge({
-    aks_log_analytics_workspace = module.aks.azurerm_log_analytics_workspace_id
-    }, length(module.application_insights) > 0 ? {
-    application_insights = module.application_insights[0].id
-    } : {}, length(module.prometheus_monitor_workspace) > 0 ? {
-    prometheus_monitor_workspace = module.prometheus_monitor_workspace[0].default_data_collection_endpoint_id
-    } : {}, length(module.prometheus_monitor_data_collection) > 0 ? {
-    prometheus_data_collection = module.prometheus_monitor_data_collection[0].data_collection_endpoint_id
-  } : {})
+  monitor_private_link_scoped_resources = merge(
+    {
+      aks_log_analytics_workspace = {
+        id   = module.aks.azurerm_log_analytics_workspace_id
+        name = module.aks.azurerm_log_analytics_workspace_name
+      }
+    },
+    length(module.application_insights) > 0 ? {
+      application_insights = {
+        id   = module.application_insights[0].id
+        name = module.application_insights[0].name
+      }
+    } : {},
+    length(module.prometheus_monitor_workspace) > 0 ? {
+      prometheus_monitor_workspace = {
+        id   = module.prometheus_monitor_workspace[0].default_data_collection_endpoint_id
+        name = module.prometheus_monitor_workspace[0].name
+      }
+    } : {},
+    length(module.prometheus_monitor_data_collection) > 0 ? {
+      prometheus_monitor_data_collection = {
+        id   = module.prometheus_monitor_data_collection[0].data_collection_endpoint_id
+        name = module.prometheus_monitor_data_collection[0].data_collection_endpoint_name
+      }
+    } : {}
+  )
 
   udr_routes = {
     all-traffic = local.udr_outbound_route

--- a/main.tf
+++ b/main.tf
@@ -505,7 +505,7 @@ module "monitor_private_link_scope" {
     resource_name = module.resource_names["monitor_private_link_scope"].standard
   })
 
-  linked_resource_ids = local.monitor_private_link_scoped_resource_ids
+  linked_resource_ids = { for key, resource in local.monitor_private_link_scoped_resources : resource.name => resource.id }
 
   depends_on = [module.resource_group, module.aks, module.application_insights, module.prometheus_monitor_workspace, module.prometheus_monitor_data_collection]
 }
@@ -567,10 +567,10 @@ module "monitor_private_link_scoped_service" {
   source  = "terraform.registry.launch.nttdata.com/module_primitive/monitor_private_link_scoped_service/azurerm"
   version = "~> 1.0"
 
-  for_each = var.brown_field_monitor_private_link_scope_id != null ? local.monitor_private_link_scoped_resource_ids : {}
+  for_each = var.brown_field_monitor_private_link_scope_id != null ? local.monitor_private_link_scoped_resources : {}
 
   monitor_private_link_scope_id = var.brown_field_monitor_private_link_scope_id
 
-  name        = each.key
-  resource_id = each.value
+  name        = each.value.name
+  resource_id = each.value.id
 }


### PR DESCRIPTION
Update naming for `azurerm_monitor_private_link_scoped_service` resources to use the actual resource name rather than a generic key, to avoid naming conflicts